### PR TITLE
ci: add frontend and backend checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm install
+        working-directory: frontend
+      - run: npm run check
+        working-directory: frontend
+      - run: npm run lint
+        working-directory: frontend
+
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo check
+        working-directory: backend
+      - run: cargo test
+        working-directory: backend
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+        working-directory: backend


### PR DESCRIPTION
## Summary
- add CI workflow for frontend npm checks and linting
- run cargo check, test, and clippy on backend

## Testing
- `cargo check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `npm run check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3ca3b8ddc832aa7f2f5a11d576c30