### PR TITLE
frontend: generalize cell components

### DIFF
--- a/frontend/src/lib/components/item-cell/ItemCell.svelte
+++ b/frontend/src/lib/components/item-cell/ItemCell.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
 	import { Copy, X } from '@lucide/svelte';
 	import { Button } from '$lib/components/ui/button';
-	import ResourceCellDropdown from './resource-cell-dropdown.svelte';
+	import ItemCellDropdown from './ItemCellDropdown.svelte';
 
 	export interface Props {
-		resources: string[];
+		items: string[];
 	}
 
-	const { resources = [] }: Props = $props();
+	const { items = [] }: Props = $props();
 
-	const hasResources = $derived(() => resources.length > 0);
+	const hasItems = $derived(() => items.length > 0);
 </script>
 
 <div class="relative group align-top">
 	<div class="min-h-12 flex flex-col gap-1">
-		{#if hasResources()}
-			{#each resources as resource (resource)}
+		{#if hasItems()}
+			{#each items as item (item)}
 				<div class="flex items-center justify-between bg-blue-50 px-2 py-1 rounded text-xs">
-					<span class="text-blue-800">{resource}</span>
+					<span class="text-blue-800">{item}</span>
 
 					<!-- Remove (disabled, visual only) -->
 					<Button
@@ -26,7 +26,7 @@
 						disabled
 						aria-disabled="true"
 						class="ml-1 h-auto w-auto p-0 rounded text-blue-600 hover:text-red-600 hover:bg-transparent focus-visible:ring-1"
-						title="Remove resource"
+						title="Remove item"
 					>
 						<X size={12} aria-hidden="true" />
 					</Button>
@@ -41,7 +41,7 @@
 			class="flex items-center gap-1 mt-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
 		>
 			<!-- Add -->
-			<ResourceCellDropdown />
+			<ItemCellDropdown />
 
 			<Button
 				variant="ghost"

--- a/frontend/src/lib/components/item-cell/ItemCellDropdown.svelte
+++ b/frontend/src/lib/components/item-cell/ItemCellDropdown.svelte
@@ -13,10 +13,10 @@
 	import { Label } from '$lib/components/ui/label';
 	import { Checkbox } from '$lib/components/ui/checkbox';
 
-	type Resource = { name: string; available: boolean };
+	type Item = { name: string; available: boolean };
 
 	// Demo data
-	let resources = $state<Resource[]>([
+	let items = $state<Item[]>([
 		{ name: 'AUV-Alpha', available: true },
 		{ name: 'AUV-Bravo', available: true },
 		{ name: 'UUV-Charlie', available: false },
@@ -34,10 +34,10 @@
 	const normalizedQuery = $derived(query.trim().toLowerCase());
 
 	// If showUnavailable is false, filter out unavailable items. Otherwise include all.
-	const filteredResources = $derived(
-		resources
-			.filter((r) => showUnavailable || r.available)
-			.filter((r) => r.name.toLowerCase().includes(normalizedQuery))
+	const filteredItems = $derived(
+		items
+			.filter((i) => showUnavailable || i.available)
+			.filter((i) => i.name.toLowerCase().includes(normalizedQuery))
 	);
 </script>
 
@@ -47,22 +47,22 @@
 			variant="ghost"
 			size="icon"
 			class="h-auto w-auto p-1 rounded text-blue-600 hover:text-blue-800 hover:bg-blue-50 focus-visible:ring-1"
-			title="Add resource"
+			title="Add item"
 		>
 			<Plus size={14} aria-hidden="true" />
 		</Button>
 	</DropdownMenuTrigger>
 
 	<DropdownMenuContent class="w-64">
-		<DropdownMenuLabel>Find Resources</DropdownMenuLabel>
+		<DropdownMenuLabel>Find Items</DropdownMenuLabel>
 
 		<div class="px-2 py-2 space-y-3">
 			<div class="space-y-1">
 				<Input
-					id="resource-search"
+					id="item-search"
 					placeholder="Start typing…"
 					autocomplete="off"
-					aria-label="Filter resources by name"
+					aria-label="Filter items by name"
 					bind:value={query}
 				/>
 			</div>
@@ -71,21 +71,21 @@
 				<Checkbox
 					id="show-unavailable"
 					bind:checked={showUnavailable}
-					aria-label="Show unavailable resources"
+					aria-label="Show unavailable items"
 				/>
 				<Label for="show-unavailable">Show unavailable</Label>
 			</div>
 		</div>
 
 		<DropdownMenuGroup>
-			{#if filteredResources.length === 0}
+			{#if filteredItems.length === 0}
 				<DropdownMenuItem disabled>No matches</DropdownMenuItem>
 			{:else}
-				{#each filteredResources as r (r)}
+				{#each filteredItems as i (i)}
 					<DropdownMenuItem>
 						<span class="flex w-full items-center justify-between">
-							<span>{r.name}</span>
-							{#if !r.available}
+							<span>{i.name}</span>
+							{#if !i.available}
 								<span class="text-xs text-muted-foreground">unavailable</span>
 							{/if}
 						</span>

--- a/frontend/src/lib/components/item-cell/index.ts
+++ b/frontend/src/lib/components/item-cell/index.ts
@@ -1,0 +1,1 @@
+export { default as ItemCell } from './ItemCell.svelte';

--- a/frontend/src/lib/components/resource-cell/index.ts
+++ b/frontend/src/lib/components/resource-cell/index.ts
@@ -1,1 +1,0 @@
-export { default as ResourceCell } from './resource-cell.svelte';

--- a/frontend/src/routes/columns.ts
+++ b/frontend/src/routes/columns.ts
@@ -1,4 +1,4 @@
-import { ResourceCell } from '$lib/components/resource-cell';
+import { ItemCell } from '$lib/components/item-cell';
 import { renderComponent, type ColumnDef } from '@tanstack/svelte-table';
 
 // --- Row model for the table (pivoted) ---
@@ -33,8 +33,8 @@ export function makeColumns(months: string[]): ColumnDef<ProjectMonthMatrixRow>[
 		header: m,
 		accessorFn: (row) => row.cells[i].resources,
 		cell: ({ getValue }) => {
-			const resources = (getValue() as RowResource[]).map((r) => r.name);
-			return renderComponent(ResourceCell, { resources });
+			const items = (getValue() as RowResource[]).map((r) => r.name);
+			return renderComponent(ItemCell, { items });
 		}
 	}));
 


### PR DESCRIPTION
## Summary
- rename resource-specific dropdown to generic `ItemCellDropdown`
- convert `ResourceCell` into reusable `ItemCell`
- update table column renderer to use generic item cell
- use PascalCase filenames for item cell components

## Testing
- `npm run lint`
- `npm run test` *(fails: browser executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c66844512c832a8b54f73f7096b035