### PR TITLE
frontend: add unit tests for item cell and columns

### DIFF
--- a/frontend/src/lib/components/item-cell/ItemCell.svelte.spec.ts
+++ b/frontend/src/lib/components/item-cell/ItemCell.svelte.spec.ts
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, it, expect } from 'vitest';
+import ItemCell from './ItemCell.svelte';
+
+describe('ItemCell', () => {
+	it('renders provided items', () => {
+		render(ItemCell, { items: ['Alpha', 'Bravo'] });
+		expect(screen.getByText('Alpha')).toBeDefined();
+		expect(screen.getByText('Bravo')).toBeDefined();
+		expect(screen.queryByText('-')).toBeNull();
+	});
+
+	it('shows placeholder when no items', () => {
+		render(ItemCell, { items: [] });
+		expect(screen.getByText('-')).toBeDefined();
+	});
+});

--- a/frontend/src/routes/columns.spec.ts
+++ b/frontend/src/routes/columns.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { makeColumns, type ProjectMonthMatrixRow } from './columns';
+
+describe('makeColumns', () => {
+	it('creates a project column and one column per month', () => {
+		const months = ['2025-06', '2025-07'];
+		const columns = makeColumns(months);
+		expect(columns).toHaveLength(3);
+		expect(columns[0].id).toBe('project');
+		expect(columns[0].header).toBe('Project');
+		expect(columns[1].id).toBe('2025-06');
+		expect(columns[2].id).toBe('2025-07');
+
+		const row: ProjectMonthMatrixRow = {
+			projectId: 'p1',
+			projectName: 'Project One',
+			cells: [
+				{ resources: [{ id: 'r1', name: 'Res1' }] },
+				{ resources: [{ id: 'r2', name: 'Res2' }] }
+			]
+		};
+		const accessor = columns[1].accessorFn!;
+		expect(accessor(row)).toEqual(row.cells[0].resources);
+	});
+});


### PR DESCRIPTION
## Summary
- test ItemCell placeholder and rendered items
- cover makeColumns column creation and accessor logic

## Testing
- `npm run lint`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c69e46b810832a883584af85691289