### PR TITLE
frontend: forward add callback to table component

### DIFF
--- a/frontend/src/lib/components/item-cell/ItemCell.svelte
+++ b/frontend/src/lib/components/item-cell/ItemCell.svelte
@@ -5,9 +5,10 @@
 
 	export interface Props {
 		items: string[];
+		onAdd: (name: string) => void;
 	}
 
-	const { items = [] }: Props = $props();
+	const { items = [], onAdd }: Props = $props();
 
 	const hasItems = $derived(() => items.length > 0);
 </script>
@@ -41,7 +42,7 @@
 			class="flex items-center gap-1 mt-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity"
 		>
 			<!-- Add -->
-			<ItemCellDropdown />
+			<ItemCellDropdown {onAdd} />
 
 			<Button
 				variant="ghost"

--- a/frontend/src/lib/components/item-cell/ItemCell.svelte.spec.ts
+++ b/frontend/src/lib/components/item-cell/ItemCell.svelte.spec.ts
@@ -4,14 +4,14 @@ import ItemCell from './ItemCell.svelte';
 
 describe('ItemCell', () => {
 	it('renders provided items', () => {
-		render(ItemCell, { props: { items: ['Alpha', 'Bravo'] } });
+		render(ItemCell, { props: { items: ['Alpha', 'Bravo'], onAdd: () => {} } });
 		expect(screen.getByText('Alpha')).toBeDefined();
 		expect(screen.getByText('Bravo')).toBeDefined();
 		expect(screen.queryByText('-')).toBeNull();
 	});
 
 	it('shows placeholder when no items', () => {
-		render(ItemCell, { props: { items: [] } });
+		render(ItemCell, { props: { items: [], onAdd: () => {} } });
 		expect(screen.getByText('-')).toBeDefined();
 	});
 });

--- a/frontend/src/lib/components/item-cell/ItemCellDropdown.svelte
+++ b/frontend/src/lib/components/item-cell/ItemCellDropdown.svelte
@@ -15,6 +15,12 @@
 
 	type Item = { name: string; available: boolean };
 
+	export interface Props {
+		onAdd: (name: string) => void;
+	}
+
+	const { onAdd }: Props = $props();
+
 	// Demo data
 	let items = $state<Item[]>([
 		{ name: 'AUV-Alpha', available: true },
@@ -82,7 +88,7 @@
 				<DropdownMenuItem disabled>No matches</DropdownMenuItem>
 			{:else}
 				{#each filteredItems as i (i)}
-					<DropdownMenuItem>
+					<DropdownMenuItem onSelect={() => onAdd(i.name)}>
 						<span class="flex w-full items-center justify-between">
 							<span>{i.name}</span>
 							{#if !i.available}

--- a/frontend/src/lib/components/item-cell/ItemCellDropdown.svelte.spec.ts
+++ b/frontend/src/lib/components/item-cell/ItemCellDropdown.svelte.spec.ts
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { describe, it, expect, vi } from 'vitest';
+import ItemCellDropdown from './ItemCellDropdown.svelte';
+
+describe('ItemCellDropdown', () => {
+	it('calls onAdd when an item is selected', async () => {
+		const onAdd = vi.fn();
+		render(ItemCellDropdown, { props: { onAdd } });
+
+		const trigger = document.querySelector('[data-dropdown-menu-trigger]') as HTMLElement;
+		await fireEvent.pointerDown(trigger);
+		await fireEvent.pointerUp(trigger);
+
+		const option = await screen.findByRole('menuitem', { name: 'AUV-Alpha' });
+		await fireEvent.click(option);
+
+		expect(onAdd).toHaveBeenCalledWith('AUV-Alpha');
+	});
+});

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-	import type { ColumnDef } from '@tanstack/table-core';
 	import { gql, GraphQLClient } from 'graphql-request';
 	import { onMount } from 'svelte';
 	import DataTable from './DataTable.svelte';
-	import { makeColumns, type ProjectMonthMatrixRow } from './columns';
+	import type { ProjectMonthMatrixRow } from './columns';
 
 	// After you run codegen with the new operation below, these types will exist:
 	import type {
@@ -64,7 +63,7 @@
 
 	// --- state ---
 	let rows = $state<ProjectMonthMatrixRow[]>([]);
-	let columns = $state<ColumnDef<ProjectMonthMatrixRow>[]>([]);
+	let months = $state<string[]>([]);
 	let error = $state<string | null>(null);
 	let loading = $state(true);
 
@@ -75,7 +74,7 @@
 		try {
 			const res = await fetchProjectMonthMatrix(requestedMonths);
 			rows = res.rows;
-			columns = makeColumns(res.months);
+			months = res.months;
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
 		} finally {
@@ -90,5 +89,5 @@
 {:else if error}
 	<p style="color: crimson;">Error: {error}</p>
 {:else}
-	<DataTable {columns} data={rows} />
+	<DataTable data={rows} {months} />
 {/if}

--- a/frontend/src/routes/DataTable.svelte
+++ b/frontend/src/routes/DataTable.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { type ColumnDef } from '@tanstack/table-core';
 	import { createSvelteTable, getCoreRowModel, flexRender } from '@tanstack/svelte-table';
-	import type { ProjectMonthMatrixRow } from './columns';
+	import { makeColumns, type ProjectMonthMatrixRow } from './columns';
 	import {
 		Table,
 		TableHeader,
@@ -12,17 +11,26 @@
 	} from '$lib/components/shadcn/table';
 
 	type DataTableProps = {
-		columns: ColumnDef<ProjectMonthMatrixRow>[];
+		months: string[];
 		data: ProjectMonthMatrixRow[];
 	};
 
-	let { data, columns }: DataTableProps = $props();
+	let { data, months }: DataTableProps = $props();
+
+	function handleAdd(name: string) {
+		void name;
+		// no-op for now
+	}
+
+	const columns = $derived(() => makeColumns(months, handleAdd));
 
 	const table = createSvelteTable({
 		get data() {
 			return data;
 		},
-		columns,
+		get columns() {
+			return columns();
+		},
 		getCoreRowModel: getCoreRowModel()
 	});
 </script>
@@ -56,7 +64,7 @@
 				</TableRow>
 			{:else}
 				<TableRow>
-					<TableCell colspan={columns.length} class="h-24 text-center">No results.</TableCell>
+					<TableCell colspan={columns().length} class="h-24 text-center">No results.</TableCell>
 				</TableRow>
 			{/each}
 		</TableBody>

--- a/frontend/src/routes/columns.spec.ts
+++ b/frontend/src/routes/columns.spec.ts
@@ -4,7 +4,7 @@ import { makeColumns, type ProjectMonthMatrixRow } from './columns';
 describe('makeColumns', () => {
 	it('creates a project column and one column per month', () => {
 		const months = ['2025-06', '2025-07'];
-		const columns = makeColumns(months);
+		const columns = makeColumns(months, () => {});
 		expect(columns).toHaveLength(3);
 		expect(columns[0].id).toBe('project');
 		expect(columns[0].header).toBe('Project');

--- a/frontend/src/routes/columns.ts
+++ b/frontend/src/routes/columns.ts
@@ -18,7 +18,8 @@ export interface ProjectMonthMatrixRow {
 // --- TanStack columns (dynamic per months) ---
 // Kept concise: use accessorFn and a local cast in the cell to avoid verbose generics
 export function makeColumns(
-	months: string[]
+	months: string[],
+	onAdd: (name: string) => void
 ): AccessorFnColumnDef<ProjectMonthMatrixRow, unknown>[] {
 	// First fixed column for project name
 	const fixed: AccessorFnColumnDef<ProjectMonthMatrixRow, unknown>[] = [
@@ -36,7 +37,7 @@ export function makeColumns(
 		accessorFn: (row) => row.cells[i].resources,
 		cell: ({ getValue }) => {
 			const items = (getValue() as RowResource[]).map((r) => r.name);
-			return renderComponent(ItemCell, { items });
+			return renderComponent(ItemCell, { items, onAdd });
 		}
 	}));
 


### PR DESCRIPTION
## Summary
- require onAdd callbacks for ItemCell and ItemCellDropdown
- test ItemCellDropdown adds item via select event

## Testing
- `npm run lint`
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7b721f4dc832a99c59313c02be444